### PR TITLE
Rename example variable to match comment below

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ import { generateTOTP, getTOTPAuthUri, verifyTOTP } from '@epic-web/totp'
 
 // Here's how to use the default config. All the options are returned:
 const { secret, period, digits, algorithm } = generateTOTP()
-const uri = getTOTPAuthUri({
+const otpUri = getTOTPAuthUri({
 	period,
 	digits,
 	algorithm,


### PR DESCRIPTION
Hi @kentcdodds 👋  Hope everything is great with you :)

Just a quick PR to match the name of the `const` identifier from `uri` to `otpUri` (the same name chosen in the QR code comment below)

```js
// optional, but recommended: import * as QRCode from 'qrcode'
// const qrCode = await QRCode.toDataURL(otpUri)
```