### PR TITLE
Implement charSet options

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ is robust, there's room for improvement.
 By introducing a customizable character set feature, you can exponentially
 increase the entropy of the OTPs, making them much more secure against
 brute-force attacks. For example, if you extend your character set to include 26
-lowercase letters and 10 digits, a 6-character OTP would have 36^6 = 2.1 billion
+uppercase letters and 10 digits, a 6-character OTP would have 36^6 = 2.1 billion
 combinations. When paired with rate-limiting mechanisms, this configuration
 becomes practically impervious to brute-force attacks.
 
@@ -189,7 +189,7 @@ const { otp, secret, period, digits, algorithm, charSet } = generateTOTP({
 	charSet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', // custom character set
 })
 
-// Remember to save the charSet to the database as well.
+// Remember to save the charSet to your database as well.
 
 // To verify
 const isValid = verifyTOTP({

--- a/README.md
+++ b/README.md
@@ -152,6 +152,59 @@ if (isValid) {
 }
 ```
 
+## Customizable Character Set for Increased Security
+
+### Why Charset Matters
+
+When it comes to security, every bit of entropy counts. Entropy measures the
+unpredictability and in turn the security of your OTPs. The traditional TOTP
+setup often employs a 6-digit numerical code, providing a million (10^6)
+combinations. This is the default behaviour for this implementation. While that
+is robust, there's room for improvement.
+
+By introducing a customizable character set feature, you can exponentially
+increase the entropy of the OTPs, making them much more secure against
+brute-force attacks. For example, if you extend your character set to include 26
+lowercase letters and 10 digits, a 6-character OTP would have 36^6 = 2.1 billion
+combinations. When paired with rate-limiting mechanisms, this configuration
+becomes practically impervious to brute-force attacks.
+
+### Potential for Main Form of Authentication
+
+With this added complexity, TOTPs can, in theory, be used as the primary form of
+authentication, rather than just a second factor. This is particularly useful
+for applications requiring heightened security.
+
+### Usage with Custom Character Set
+
+In addition to the existing options, you can specify a charSet in both
+`generateTOTP` and `verifyTOTP`.
+
+Here's how you can generate an OTP with a custom character set:
+
+```js
+import { generateTOTP, verifyTOTP } from '@epic-web/totp'
+
+const { otp, secret, period, digits, algorithm, charSet } = generateTOTP({
+	charSet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', // custom character set
+})
+
+// Remember to save the charSet to the database as well.
+
+// To verify
+const isValid = verifyTOTP({
+	otp,
+	secret,
+	period,
+	digits,
+	algorithm,
+	charSet,
+})
+```
+
+Just as an aside, you probably want to exclude the letter O and the number 0 to
+make it easier for users to enter the code.
+
 ## API
 
 This library is built with `jsdoc`, so hopefully your editor supports that and
@@ -175,7 +228,7 @@ will show you all this stuff, but just in case, here's that:
  * base32 encoded (you can use https://npm.im/thirty-two). Defaults to a random
  * secret: base32.encode(crypto.randomBytes(10)).toString().
  * @param {string} [options.charSet='0123456789'] - The character set to use, defaults to the numbers 0-9.
- * @returns {{otp: string, secret: string, period: number, digits: number, algorithm: string}}
+ * @returns {{otp: string, secret: string, period: number, digits: number, algorithm: string, charSet: string}}
  * The OTP, secret, and config options used to generate the OTP.
  */
 ```

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ will show you all this stuff, but just in case, here's that:
  * @param {string} [options.secret] The secret to use for the TOTP. It should be
  * base32 encoded (you can use https://npm.im/thirty-two). Defaults to a random
  * secret: base32.encode(crypto.randomBytes(10)).toString().
+ * @param {string} [options.charSet='0123456789'] - The character set to use, defaults to the numbers 0-9.
  * @returns {{otp: string, secret: string, period: number, digits: number, algorithm: string}}
  * The OTP, secret, and config options used to generate the OTP.
  */
@@ -193,6 +194,7 @@ will show you all this stuff, but just in case, here's that:
  * @param {number} [options.period] The number of seconds for the OTP to be valid.
  * @param {number} [options.digits] The length of the OTP.
  * @param {string} [options.algorithm] The algorithm to use.
+ * @param {string} [options.charSet] The character set to use, defaults to the numbers 0-9.
  * @param {number} [options.window] The number of OTPs to check before and after
  * the current OTP. Defaults to 1.
  *

--- a/index.js
+++ b/index.js
@@ -188,6 +188,7 @@ export function getTOTPAuthUri({
  * @param {number} [options.period] The number of seconds for the OTP to be valid.
  * @param {number} [options.digits] The length of the OTP.
  * @param {string} [options.algorithm] The algorithm to use.
+ * @param {string} [options.charSet] - The character set to use, defaults to the numbers 0-9.
  * @param {number} [options.window] The number of OTPs to check before and after
  * the current OTP. Defaults to 1.
  *
@@ -201,6 +202,7 @@ export function verifyTOTP({
 	period,
 	digits,
 	algorithm,
+	charSet,
 	window = DEFAULT_WINDOW,
 }) {
 	return verifyHOTP(otp, base32.decode(secret), {
@@ -208,6 +210,7 @@ export function verifyTOTP({
 		digits,
 		window,
 		algorithm,
+		charSet,
 	})
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -17,7 +17,7 @@ test('options can be customized', () => {
 		algorithm: 'SHA256',
 		period: 60,
 		digits: 8,
-		secret: base32.encode(Math.random().toString(16).slice(2)),
+		secret: base32.encode(Math.random().toString(16).slice(2)).toString(),
 	}
 	const { otp, ...config } = generateTOTP(options)
 	assert.deepStrictEqual(config, options)
@@ -85,6 +85,16 @@ test('Generating and verifying also works with the algorithm name alias', () => 
 
 	const result = verifyTOTP({ otp, secret, algorithm: 'sha1' })
 	assert.notStrictEqual(result, null)
+})
+
+test('Charset defaults to numbers', () => {
+	const { otp } = generateTOTP()
+	assert.match(otp, /^[0-9]+$/)
+})
+
+test('Charset can be customized', () => {
+	const { otp } = generateTOTP({ charSet: 'abcdef' })
+	assert.match(otp, /^[abcdef]+$/)
 })
 
 test('OTP Auth URI can be generated', () => {

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
-import { test, afterEach } from 'node:test'
-import * as base32 from 'thirty-two'
+import { test } from 'node:test'
+import base32 from 'thirty-two'
 import { generateTOTP, getTOTPAuthUri, verifyTOTP } from './index.js'
 
 test('OTP can be generated and verified', () => {
@@ -18,6 +18,7 @@ test('options can be customized', () => {
 		period: 60,
 		digits: 8,
 		secret: base32.encode(Math.random().toString(16).slice(2)).toString(),
+		charSet: 'abcdef',
 	}
 	const { otp, ...config } = generateTOTP(options)
 	assert.deepStrictEqual(config, options)


### PR DESCRIPTION
This allows the user to define different charsets for the OTP to be in. This is incredibly useful for increasing the entropy and time-to-crack when dealing with brute force attacks.

When using a substantially larger character set, the increased complexity means, in theory, you could use this as a main form of authentication always rather than relying on a 2FA setup. 

e.g. 10 digits at length 6 = 1 Million possibilities

However,

26 letters + 10 digits at length 6 = 36^6 = 2.1 Billion options.

With a rate limitting system, this is practically uncrackable.