### PR TITLE
fix: reverse TOTP code

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function generateHOTP(
 
 	let hotp = ''
 	for (let i = 0; i < digits; i++) {
-		hotp += charSet.charAt(hotpVal % charSet.length)
+		hotp = charSet.charAt(hotpVal % charSet.length) + hotp
 		hotpVal = Math.floor(hotpVal / charSet.length)
 	}
 


### PR DESCRIPTION
We were looking for a 2FA library and could not find one that is maintained neither. So, we were pretty happy that this one was announced and we wanted to try it out.

However, the TOTP codes that are generated by this library don't work / are different from the authenticator apps. Debugging the issue, it looks like the codes are reversed (`123456` instead of `654321`) after #4.

The tests were passing before and are still passing now. Does it make sense to add a test to check for a specific OTP code with a given secret to be sure the implementation is not broken? I am happy to add a test for this.
This is not easily possible right now because `generateTOTP` depends on the current time and `generateHOTP` is not exported. Would you rather mock the time somehow or export the HOTP methods as well? If neither is preferred, a second file that re-exports the TOTP functions could work as well.