### PR TITLE
Use node import for 'crypto' to ease Cloudflare deploy with Vite

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
  * This was copy/paste/modified/tested from https://npm.im/notp (MIT)
  */
-import * as crypto from 'crypto'
+import * as crypto from 'node:crypto'
 
 /**
  * @type {{ encode: (data: string | import('buffer').Buffer) => string, decode: (data: string) => import('buffer').Buffer }}


### PR DESCRIPTION
Use node import for 'crypto' node builtin module to ease Cloudflare deploy with Vite.

Cloudflare offers some node.js compatibility if you switch it on and use the `node:` prefix in your imports. See: https://developers.cloudflare.com/workers/runtime-apis/nodejs/

This eases Remix deployment with the Vite compiler since no additional Vite configuration is needed. Otherwise, you may need to specify resolve.alias's and srr.noExternal's, which can get tricky if `totp` is a dependency of a dependency as is the case for `remix-auth-totp`. 

Note that version 3 of `remix-auth-totp` will include a similar change. (https://github.com/dev-xo/remix-auth-totp/pull/45)