### PR TITLE
Use new base 32 encode and decode with type fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const DEFAULT_PERIOD = 30
  * Generates a HMAC-based One Time Password (HOTP) using the provided secret and
  * configuration options.
  *
- * @param {Buffer} secret - The secret used to generate the HOTP.
+ * @param {ArrayBuffer} secret - The secret used to generate the HOTP.
  * @param {Object} options - The configuration options for the HOTP.
  * @param {number} [options.counter=0] - The counter value to use for the HOTP.
  * Defaults to 0.
@@ -42,7 +42,8 @@ function generateHOTP(
 	} = {}
 ) {
 	const byteCounter = Buffer.from(intToBytes(counter))
-	const hmac = crypto.createHmac(algorithm, secret)
+	const secretBuffer = Buffer.from(secret)
+	const hmac = crypto.createHmac(algorithm, secretBuffer)
 	const digest = hmac.update(byteCounter).digest('hex')
 	const hashBytes = hexToBytes(digest)
 	const offset = hashBytes[19] & 0xf

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 import { test } from 'node:test'
-import base32 from 'thirty-two'
+import base32Encode from 'base32-encode'
 import { generateTOTP, getTOTPAuthUri, verifyTOTP } from './index.js'
 
 test('OTP can be generated and verified', () => {
@@ -17,7 +17,10 @@ test('options can be customized', () => {
 		algorithm: 'SHA256',
 		period: 60,
 		digits: 8,
-		secret: base32.encode(Math.random().toString(16).slice(2)).toString(),
+		secret: base32Encode(
+			new TextEncoder().encode(Math.random().toString(16).slice(2)),
+			'RFC4648'
+		).toString(),
 		charSet: 'abcdef',
 	}
 	const { otp, ...config } = generateTOTP(options)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "thirty-two": "^1.0.2"
+        "base32-decode": "^1.0.0",
+        "base32-encode": "^2.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.4.5"
@@ -24,12 +25,31 @@
       "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
       "dev": true
     },
-    "node_modules/thirty-two": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
-      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+    "node_modules/base32-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base32-decode/-/base32-decode-1.0.0.tgz",
+      "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g==",
+      "license": "MIT"
+    },
+    "node_modules/base32-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-2.0.0.tgz",
+      "integrity": "sha512-mlmkfc2WqdDtMl/id4qm3A7RjW6jxcbAoMjdRmsPiwQP0ufD4oXItYMnPgVHe80lnAIy+1xwzhHE1s4FoIceSw==",
+      "license": "MIT",
+      "dependencies": {
+        "to-data-view": "^2.0.0"
+      },
       "engines": {
-        "node": ">=0.2.6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/to-data-view": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-2.0.0.tgz",
+      "integrity": "sha512-RGEM5KqlPHr+WVTPmGNAXNeFEmsBnlkxXaIfEpUYV0AST2Z5W1EGq9L/MENFrMMmL2WQr1wjkmZy/M92eKhjYA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     }
   },
@@ -40,10 +60,23 @@
       "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
       "dev": true
     },
-    "thirty-two": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
-      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA=="
+    "base32-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base32-decode/-/base32-decode-1.0.0.tgz",
+      "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g=="
+    },
+    "base32-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-2.0.0.tgz",
+      "integrity": "sha512-mlmkfc2WqdDtMl/id4qm3A7RjW6jxcbAoMjdRmsPiwQP0ufD4oXItYMnPgVHe80lnAIy+1xwzhHE1s4FoIceSw==",
+      "requires": {
+        "to-data-view": "^2.0.0"
+      }
+    },
+    "to-data-view": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-2.0.0.tgz",
+      "integrity": "sha512-RGEM5KqlPHr+WVTPmGNAXNeFEmsBnlkxXaIfEpUYV0AST2Z5W1EGq9L/MENFrMMmL2WQr1wjkmZy/M92eKhjYA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "thirty-two": "^1.0.2"
+    "base32-decode": "^1.0.0",
+    "base32-encode": "^2.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test --test-reporter spec --experimental-test-coverage *.test.js",
-    "test:watch": "node --test --test-reporter spec --watch *.test.js"
+    "test:watch": "node --test --test-reporter spec --watch *.test.js",
+    "typecheck": "npx -p typescript tsc --declaration --emitDeclarationOnly --allowJs --checkJs --downlevelIteration --module nodenext --moduleResolution nodenext --target es2022 --outDir . index.js"
   },
   "keywords": [
     "totp",


### PR DESCRIPTION
Fix for issue https://github.com/epicweb-dev/totp/issues/8

This package is used by remix-auth-totp package which is breaking when deployed to aws lambda using sst.

The proposed fix in this PR was tested inside the project where I was experiencing the issue. I had to alter the tests slightly to make them work. Not sure if these changes imply any breaking changes.

Related issue in remix-auth-totp: https://github.com/dev-xo/remix-auth-totp/issues/69

Related PR in remix-auth-totp: https://github.com/dev-xo/remix-auth-totp/pull/70

This PR also contains type changes required for typescript. 

@kentcdodds I added a typecheck script to package.json for checking types for future changes which seems to be the latest convention (and where I was looking). 