### PR TITLE
Convert Buffer and node crypto to web apis

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -3,18 +3,19 @@ import { test } from 'node:test'
 import base32Encode from 'base32-encode'
 import { generateTOTP, getTOTPAuthUri, verifyTOTP } from './index.js'
 
-test('OTP can be generated and verified', () => {
-	const { secret, otp, algorithm, period, digits } = generateTOTP()
-	assert.strictEqual(algorithm, 'SHA1')
+test('OTP can be generated and verified', async () => {
+	const { secret, otp, algorithm, period, digits } = await generateTOTP()
+
+	assert.strictEqual(algorithm, 'SHA-1')
 	assert.strictEqual(period, 30)
 	assert.strictEqual(digits, 6)
-	const result = verifyTOTP({ otp, secret })
+	const result = await verifyTOTP({ otp, secret })
 	assert.deepStrictEqual(result, { delta: 0 })
 })
 
-test('options can be customized', () => {
+test('options can be customized', async () => {
 	const options = {
-		algorithm: 'SHA256',
+		algorithm: 'SHA-256',
 		period: 60,
 		digits: 8,
 		secret: base32Encode(
@@ -23,86 +24,86 @@ test('options can be customized', () => {
 		).toString(),
 		charSet: 'abcdef',
 	}
-	const { otp, ...config } = generateTOTP(options)
+	const { otp, ...config } = await generateTOTP(options)
 	assert.deepStrictEqual(config, options)
-	const result = verifyTOTP({ otp, ...config })
+	const result = await verifyTOTP({ otp, ...config })
 	assert.deepStrictEqual(result, { delta: 0 })
 })
 
-test('Verify TOTP within the specified time window', () => {
-	const { otp, secret } = generateTOTP()
-	const result = verifyTOTP({ otp, secret, window: 0 })
+test('Verify TOTP within the specified time window', async () => {
+	const { otp, secret } = await generateTOTP()
+	const result = await verifyTOTP({ otp, secret, window: 0 })
 	assert.notStrictEqual(result, null)
 })
 
-test('Fail to verify an invalid TOTP', () => {
+test('Fail to verify an invalid TOTP', async () => {
 	const secret = Math.random().toString()
 	const tooShortNumber = Math.random().toString().slice(2, 7)
-	const result = verifyTOTP({ otp: tooShortNumber, secret })
+	const result = await verifyTOTP({ otp: tooShortNumber, secret })
 	assert.strictEqual(result, null)
 })
 
 test('Fail to verify TOTP outside the specified time window', async () => {
-	const { otp, secret: key } = generateTOTP({ period: 0.0001 })
+	const { otp, secret: key } = await generateTOTP({ period: 0.0001 })
 	await new Promise((resolve) => setTimeout(resolve, 1))
-	const result = verifyTOTP({ otp, secret: key })
+	const result = await verifyTOTP({ otp, secret: key })
 	assert.strictEqual(result, null)
 })
 
 test('Clock drift is handled by window', async () => {
 	// super small period
-	const { otp, secret: key, period } = generateTOTP({ period: 0.0001 })
+	const { otp, secret: key, period } = await generateTOTP({ period: 0.0001 })
 	// waiting a tiny bit
 	await new Promise((resolve) => setTimeout(resolve, 1))
 	// super big window (to accomodate slow machines running this test)
-	const result = verifyTOTP({ otp, secret: key, window: 200, period })
+	const result = await verifyTOTP({ otp, secret: key, window: 200, period })
 	// should still validate
 	assert.notDeepStrictEqual(result, null)
 })
 
-test('Setting a different period config for generating and verifying will fail', () => {
+test('Setting a different period config for generating and verifying will fail', async () => {
 	const desiredPeriod = 60
-	const { otp, secret, period } = generateTOTP({
+	const { otp, secret, period } = await generateTOTP({
 		period: desiredPeriod,
 	})
 	assert.strictEqual(period, desiredPeriod)
-	const result = verifyTOTP({ otp, secret, period: period + 1 })
+	const result = await verifyTOTP({ otp, secret, period: period + 1 })
 	assert.strictEqual(result, null)
 })
 
-test('Setting a different algo config for generating and verifying will fail', () => {
-	const desiredAlgo = 'SHA512'
-	const { otp, secret, algorithm } = generateTOTP({
+test('Setting a different algo config for generating and verifying will fail', async () => {
+	const desiredAlgo = 'SHA-512'
+	const { otp, secret, algorithm } = await generateTOTP({
 		algorithm: desiredAlgo,
 	})
 	assert.strictEqual(algorithm, desiredAlgo)
-	const result = verifyTOTP({ otp, secret, algorithm: 'SHA1' })
+	const result = await verifyTOTP({ otp, secret, algorithm: 'SHA-1' })
 	assert.strictEqual(result, null)
 })
 
-test('Generating and verifying also works with the algorithm name alias', () => {
-	const desiredAlgo = 'SHA1'
-	const { otp, secret, algorithm } = generateTOTP({
+test('Generating and verifying also works with the algorithm name alias', async () => {
+	const desiredAlgo = 'SHA-1'
+	const { otp, secret, algorithm } = await generateTOTP({
 		algorithm: desiredAlgo,
 	})
 	assert.strictEqual(algorithm, desiredAlgo)
 
-	const result = verifyTOTP({ otp, secret, algorithm: 'sha1' })
+	const result = await verifyTOTP({ otp, secret, algorithm: 'sha-1' })
 	assert.notStrictEqual(result, null)
 })
 
-test('Charset defaults to numbers', () => {
-	const { otp } = generateTOTP()
+test('Charset defaults to numbers', async () => {
+	const { otp } = await generateTOTP()
 	assert.match(otp, /^[0-9]+$/)
 })
 
-test('Charset can be customized', () => {
-	const { otp } = generateTOTP({ charSet: 'abcdef' })
+test('Charset can be customized', async () => {
+	const { otp } = await generateTOTP({ charSet: 'abcdef' })
 	assert.match(otp, /^[abcdef]+$/)
 })
 
-test('OTP Auth URI can be generated', () => {
-	const { otp: _otp, secret, ...totpConfig } = generateTOTP()
+test('OTP Auth URI can be generated', async () => {
+	const { otp: _otp, secret, ...totpConfig } = await generateTOTP()
 	const issuer = Math.random().toString(16).slice(2)
 	const accountName = Math.random().toString(16).slice(2)
 	const uri = getTOTPAuthUri({

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "base32-encode": "^2.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
This PR converts all uses of Buffer and node crypto APIs to Uint8array and web crypto.

This would be a major release because it bumps the minimum node engine version and converts all exports to be async.

This makes this package fully compatibility with serverless, and would make remix-auth-totp too https://github.com/dev-xo/remix-auth-totp/pull/74

If this isn't desired, I can make a new package.