### PR TITLE
feat: add loose type hinting for hash algorithm options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ import base32Decode from 'base32-decode'
 
 /**
  * @typedef {'SHA-1' | 'SHA-256' | 'SHA-386' | 'SHA-512' | string & {}} HashAlgorithm
+ *
+ * For all available algorithms, refer to the following:
+ * https://developer.mozilla.org/en-US/docs/Web/API/HmacImportParams#hash
  */
 
 // SHA-1 is not secure, but in the context of TOTPs, it's unrealistic to expect
@@ -260,4 +263,3 @@ function getCounter(period = DEFAULT_PERIOD) {
 	const counter = Math.floor(now / 1000 / period)
 	return counter
 }
-


### PR DESCRIPTION
Basically as the name says. I've kept the type hinting loose in case we have any new algorithms that are added in the future such that they can be passed in.

Given that the type is loose and will accept any string (while providing type hinting), it won't have any breaking changes for existing projects.

Let me know your thoughts about this change and whether it's worth adding in.