### PR TITLE
fix: ensure types generate properly for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
       - name: 💪 Generate Types
         run:
           npx -p typescript tsc --declaration --emitDeclarationOnly --allowJs
-          --checkJs --downlevelIteration --module nodenext --moduleResolution
-          nodenext --target es2022 --outDir . index.js
+          --checkJs --skipLibCheck --downlevelIteration --module nodenext
+          --moduleResolution nodenext --target es2022 --outDir . index.js
 
       - name: 🚀 Release
         uses: cycjimmy/semantic-release-action@v3.2.0


### PR DESCRIPTION
The type generation step was not excluding the `node_modules` folder. I've added `--skipLibCheck`  and this resolves the following issue: 

<img width="924" alt="image" src="https://github.com/user-attachments/assets/50b25e02-8a91-4f12-b988-c212e8bb8e42" />

I think a good next step would be to add a `pr.yml` workflow to run through type checking so we don't run into these issues in the future