### PR TITLE
fix: add missing repository.url value to create new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "index.js",
     "index.d.ts"
   ],
+  "repository": {
+    "url": "https://github.com/epicweb-dev/totp"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This should allow the release to happen automatically now

Third time lucky I hope!