### PR TITLE
Allow to generate TOTP codes up to 20 character long

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ const otpUri = getTOTPAuthUri({
 const code = await getCodeFromUser()
 
 // now verify the code:
-const isValid = await verifyTOTP({ otp: code, secret, period, digits, algorithm })
+const isValid = await verifyTOTP({
+	otp: code,
+	secret,
+	period,
+	digits,
+	algorithm,
+})
 
 // if it's valid, save the secret, period, digits, and algorithm to the database
 // along with who it belongs to and use this info to verify the user when they

--- a/index.js
+++ b/index.js
@@ -77,17 +77,20 @@ export async function generateHOTP(
     BigInt(hashBytes[offset + 4]) << 24n |
     
     // we have only 20 hashBytes; if offset is 15 these indexes are out of the hashBytes
-    // fallback to zero
-    BigInt(hashBytes[offset + 5] ?? 0n) << 16n |
-    BigInt(hashBytes[offset + 6] ?? 0n) << 8n |
-    BigInt(hashBytes[offset + 7] ?? 0n)
+    // fallback to the bytes at the start of the hashBytes
+    BigInt(hashBytes[(offset + 5) % 20]) << 16n |
+    BigInt(hashBytes[(offset + 6) % 20]) << 8n |
+    BigInt(hashBytes[(offset + 7) % 20])
   }
 
 	let hotp = ''
 	const charSetLength = BigInt(charSet.length)
 	for (let i = 0; i < digits; i++) {
-		hotp = charSet.charAt(Number(hotpVal % charSetLength)) + hotp
-		hotpVal = hotpVal / charSetLength
+    hotp = charSet.charAt(Number(hotpVal % charSetLength)) + hotp
+
+    // Ensures hotpVal decreases at a fixed rate, independent of charSet length.
+    // 10n is compatible with the original TOTP algorithm used in the authenticator apps.
+    hotpVal = hotpVal / 10n
 	}
 
 	return hotp

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ export async function generateHOTP(
 		digits = DEFAULT_DIGITS,
 		algorithm = DEFAULT_ALGORITHM,
 		charSet = DEFAULT_CHAR_SET,
-	} = {}
+	} = {},
 ) {
 	const byteCounter = intToBytes(counter)
 	const key = await crypto.subtle.importKey(
@@ -52,45 +52,46 @@ export async function generateHOTP(
 		secret,
 		{ name: 'HMAC', hash: algorithm },
 		false,
-		['sign']
+		['sign'],
 	)
 	const signature = await crypto.subtle.sign('HMAC', key, byteCounter)
-  const hashBytes = new Uint8Array(signature)
-  // offset is always the last 4 bits of the signature; its value: 0-15
-  const offset = hashBytes[hashBytes.length - 1] & 0xf
+	const hashBytes = new Uint8Array(signature)
+	// offset is always the last 4 bits of the signature; its value: 0-15
+	const offset = hashBytes[hashBytes.length - 1] & 0xf
 
-  let hotpVal = 0n
-  if (digits === 6) {
-    // stay compatible with the authenticator apps and only use the bottom 32 bits of BigInt
-    hotpVal = 0n |
-    BigInt(hashBytes[offset] & 0x7f) << 24n |
-    BigInt(hashBytes[offset + 1]) << 16n |
-    BigInt(hashBytes[offset + 2]) << 8n |
-    BigInt(hashBytes[offset + 3])
-  } else {
-    // otherwise create a 64bit value from the hashBytes
-    hotpVal = 0n |
-    BigInt(hashBytes[offset] & 0x7f) << 56n |
-    BigInt(hashBytes[offset + 1]) << 48n |
-    BigInt(hashBytes[offset + 2]) << 40n |
-    BigInt(hashBytes[offset + 3]) << 32n |
-    BigInt(hashBytes[offset + 4]) << 24n |
-    
-    // we have only 20 hashBytes; if offset is 15 these indexes are out of the hashBytes
-    // fallback to the bytes at the start of the hashBytes
-    BigInt(hashBytes[(offset + 5) % 20]) << 16n |
-    BigInt(hashBytes[(offset + 6) % 20]) << 8n |
-    BigInt(hashBytes[(offset + 7) % 20])
-  }
+	let hotpVal = 0n
+	if (digits === 6) {
+		// stay compatible with the authenticator apps and only use the bottom 32 bits of BigInt
+		hotpVal =
+			0n |
+			(BigInt(hashBytes[offset] & 0x7f) << 24n) |
+			(BigInt(hashBytes[offset + 1]) << 16n) |
+			(BigInt(hashBytes[offset + 2]) << 8n) |
+			BigInt(hashBytes[offset + 3])
+	} else {
+		// otherwise create a 64bit value from the hashBytes
+		hotpVal =
+			0n |
+			(BigInt(hashBytes[offset] & 0x7f) << 56n) |
+			(BigInt(hashBytes[offset + 1]) << 48n) |
+			(BigInt(hashBytes[offset + 2]) << 40n) |
+			(BigInt(hashBytes[offset + 3]) << 32n) |
+			(BigInt(hashBytes[offset + 4]) << 24n) |
+			// we have only 20 hashBytes; if offset is 15 these indexes are out of the hashBytes
+			// fallback to the bytes at the start of the hashBytes
+			(BigInt(hashBytes[(offset + 5) % 20]) << 16n) |
+			(BigInt(hashBytes[(offset + 6) % 20]) << 8n) |
+			BigInt(hashBytes[(offset + 7) % 20])
+	}
 
 	let hotp = ''
 	const charSetLength = BigInt(charSet.length)
 	for (let i = 0; i < digits; i++) {
-    hotp = charSet.charAt(Number(hotpVal % charSetLength)) + hotp
+		hotp = charSet.charAt(Number(hotpVal % charSetLength)) + hotp
 
-    // Ensures hotpVal decreases at a fixed rate, independent of charSet length.
-    // 10n is compatible with the original TOTP algorithm used in the authenticator apps.
-    hotpVal = hotpVal / 10n
+		// Ensures hotpVal decreases at a fixed rate, independent of charSet length.
+		// 10n is compatible with the original TOTP algorithm used in the authenticator apps.
+		hotpVal = hotpVal / 10n
 	}
 
 	return hotp
@@ -125,7 +126,7 @@ async function verifyHOTP(
 		algorithm = DEFAULT_ALGORITHM,
 		charSet = DEFAULT_CHAR_SET,
 		window = DEFAULT_WINDOW,
-	} = {}
+	} = {},
 ) {
 	for (let i = counter - window; i <= counter + window; ++i) {
 		if (

--- a/index.test.js
+++ b/index.test.js
@@ -161,3 +161,43 @@ test('generateHOTP works with maximum HMAC offset value',  async () => {
       });
     });
 })
+
+test('20 digits OTP should not pad with first character of charSet regardless of the charSet length', async () => {
+	const longCharSet = 'ABCDEFGHIJKLMNPQRSTUVWXYZ123456789'
+	const shortCharSet = 'ABCDEFGHIJK'
+	
+  async function generate20DigitCodeWithCharSet(charSet) {
+
+    const iterations = 100
+    let allOtps = []
+  
+    for (let i = 0; i < iterations; i++) {
+      const { otp } = await generateTOTP({
+        algorithm: 'SHA-256',
+        charSet,
+        digits: 20,
+        period: 60 * 30,
+      })
+      allOtps.push(otp)
+  
+      // Verify the OTP only contains characters from the charSet
+      assert.match(
+        otp,
+        new RegExp(`^[${charSet}]{20}$`),
+        'OTP should be 20 characters from the charSet'
+      )
+  
+      // The first 6 characters should not all be 'A' (first char of charSet)
+      const firstSixChars = otp.slice(0, 6)
+      assert.notStrictEqual(
+        firstSixChars,
+        'A'.repeat(6),
+        'First 6 characters should not all be A'
+      )
+    }
+  }
+
+  await generate20DigitCodeWithCharSet(shortCharSet);
+  await generate20DigitCodeWithCharSet(longCharSet);
+
+})

--- a/index.test.js
+++ b/index.test.js
@@ -2,7 +2,12 @@ import assert from 'node:assert'
 import { test } from 'node:test'
 import base32Encode from 'base32-encode'
 import base32Decode from 'base32-decode'
-import { generateTOTP, getTOTPAuthUri, verifyTOTP, generateHOTP } from './index.js'
+import {
+	generateTOTP,
+	getTOTPAuthUri,
+	verifyTOTP,
+	generateHOTP,
+} from './index.js'
 
 test('OTP can be generated and verified', async () => {
 	const { secret, otp, algorithm, period, digits } = await generateTOTP()
@@ -21,7 +26,7 @@ test('options can be customized', async () => {
 		digits: 8,
 		secret: base32Encode(
 			new TextEncoder().encode(Math.random().toString(16).slice(2)),
-			'RFC4648'
+			'RFC4648',
 		).toString(),
 		charSet: 'abcdef',
 	}
@@ -134,7 +139,7 @@ test('OTP with digits > 6 should not pad with first character of charSet', async
 		assert.match(
 			otp,
 			new RegExp(`^[${charSet}]{12}$`),
-			'OTP should be 12 characters from the charSet'
+			'OTP should be 12 characters from the charSet',
 		)
 
 		// The first 6 characters should not all be 'A' (first char of charSet)
@@ -142,62 +147,59 @@ test('OTP with digits > 6 should not pad with first character of charSet', async
 		assert.notStrictEqual(
 			firstSixChars,
 			'A'.repeat(6),
-			'First 6 characters should not all be A'
+			'First 6 characters should not all be A',
 		)
 	}
 })
 
-
-test('generateHOTP works with maximum HMAC offset value',  async () => {
-  await assert.doesNotReject( async() => {
-    // These specific secret and counter values will cause offset to be 15
-    const secret = '6YY3NUMNTQ73NRH3';
-    const counter = 57988074;
-      await generateHOTP(base32Decode(secret, 'RFC4648'),{
-        counter,
-        digits: 12, // trigger the use of the 64bit htopVal
-        algorithm: 'SHA-1',
-        charSet: '0123456789',
-      });
-    });
+test('generateHOTP works with maximum HMAC offset value', async () => {
+	await assert.doesNotReject(async () => {
+		// These specific secret and counter values will cause offset to be 15
+		const secret = '6YY3NUMNTQ73NRH3'
+		const counter = 57988074
+		await generateHOTP(base32Decode(secret, 'RFC4648'), {
+			counter,
+			digits: 12, // trigger the use of the 64bit htopVal
+			algorithm: 'SHA-1',
+			charSet: '0123456789',
+		})
+	})
 })
 
 test('20 digits OTP should not pad with first character of charSet regardless of the charSet length', async () => {
 	const longCharSet = 'ABCDEFGHIJKLMNPQRSTUVWXYZ123456789'
 	const shortCharSet = 'ABCDEFGHIJK'
-	
-  async function generate20DigitCodeWithCharSet(charSet) {
 
-    const iterations = 100
-    let allOtps = []
-  
-    for (let i = 0; i < iterations; i++) {
-      const { otp } = await generateTOTP({
-        algorithm: 'SHA-256',
-        charSet,
-        digits: 20,
-        period: 60 * 30,
-      })
-      allOtps.push(otp)
-  
-      // Verify the OTP only contains characters from the charSet
-      assert.match(
-        otp,
-        new RegExp(`^[${charSet}]{20}$`),
-        'OTP should be 20 characters from the charSet'
-      )
-  
-      // The first 6 characters should not all be 'A' (first char of charSet)
-      const firstSixChars = otp.slice(0, 6)
-      assert.notStrictEqual(
-        firstSixChars,
-        'A'.repeat(6),
-        'First 6 characters should not all be A'
-      )
-    }
-  }
+	async function generate20DigitCodeWithCharSet(charSet) {
+		const iterations = 100
+		let allOtps = []
 
-  await generate20DigitCodeWithCharSet(shortCharSet);
-  await generate20DigitCodeWithCharSet(longCharSet);
+		for (let i = 0; i < iterations; i++) {
+			const { otp } = await generateTOTP({
+				algorithm: 'SHA-256',
+				charSet,
+				digits: 20,
+				period: 60 * 30,
+			})
+			allOtps.push(otp)
 
+			// Verify the OTP only contains characters from the charSet
+			assert.match(
+				otp,
+				new RegExp(`^[${charSet}]{20}$`),
+				'OTP should be 20 characters from the charSet',
+			)
+
+			// The first 6 characters should not all be 'A' (first char of charSet)
+			const firstSixChars = otp.slice(0, 6)
+			assert.notStrictEqual(
+				firstSixChars,
+				'A'.repeat(6),
+				'First 6 characters should not all be A',
+			)
+		}
+	}
+
+	await generate20DigitCodeWithCharSet(shortCharSet)
+	await generate20DigitCodeWithCharSet(longCharSet)
 })


### PR DESCRIPTION
Noticed that even with the use of BigInt the TOTP codes that are longer than 12 characters were padding the first character as it is described in issue #20.

In this PR I fixed the reduction rate of the `htopVal` variable. It is divided by 10 regardless of the size of the charSet. This change allows us to generate TOTPs up to 20 character long and stays compatible with the authenticator apps.

  